### PR TITLE
Text property for ignoring polar coordinates rotation

### DIFF
--- a/src/app/views/canvas/bounding_box.tsx
+++ b/src/app/views/canvas/bounding_box.tsx
@@ -107,10 +107,15 @@ export class BoundingBoxView extends React.Component<
           y: rect.cy,
           angle: rect.rotation,
         };
+        const baseTransform = coordinateSystem.getBaseTransform();
+        const localTransform = coordinateSystem.getLocalTransform(cx, cy);
+        if (rect.ignorePolarRotation) {
+          localTransform.angle = 0;
+        }
         const tr = Graphics.concatTransform(
           Graphics.concatTransform(
-            coordinateSystem.getBaseTransform(),
-            coordinateSystem.getLocalTransform(cx, cy)
+            baseTransform,
+            localTransform
           ),
           trCenter
         );

--- a/src/core/prototypes/common.ts
+++ b/src/core/prototypes/common.ts
@@ -248,7 +248,7 @@ export namespace BoundingBox {
     width: number;
     height: number;
     rotation: number;
-
+    ignorePolarRotation: boolean;
     anchorX: number;
     anchorY: number;
   }

--- a/src/core/prototypes/common.ts
+++ b/src/core/prototypes/common.ts
@@ -218,6 +218,7 @@ export namespace Handles {
     text: string;
     alignment: SpecTypes.TextAlignment;
     rotation: number;
+    ignorePolarRotation: boolean;
     anchorX: number;
     anchorY: number;
     textWidth: number;

--- a/src/core/prototypes/marks/text.attrs.ts
+++ b/src/core/prototypes/marks/text.attrs.ts
@@ -74,4 +74,5 @@ export interface TextElementAttributes extends AttributeMap {
 export interface TextElementProperties extends AttributeMap {
   alignment: SpecTypes.TextAlignment;
   rotation: number;
+  ignorePolarRotation: boolean;
 }

--- a/src/core/prototypes/marks/text.ts
+++ b/src/core/prototypes/marks/text.ts
@@ -294,6 +294,7 @@ export class TextElementClass extends EmphasizableMarkClass<
       cy: attrs.y + cx * sin + cy * cos,
       width: metrics.width,
       height: (metrics.middle - metrics.ideographicBaseline) * 2,
+      ignorePolarRotation: this.object.properties.ignorePolarRotation,
       rotation,
     };
   }
@@ -310,6 +311,7 @@ export class TextElementClass extends EmphasizableMarkClass<
       width: rect.width,
       height: rect.height,
       rotation: rect.rotation,
+      ignorePolarRotation: rect.ignorePolarRotation
     };
   }
 

--- a/src/core/prototypes/marks/text.ts
+++ b/src/core/prototypes/marks/text.ts
@@ -85,6 +85,7 @@ export class TextElementClass extends EmphasizableMarkClass<
       yMargin: 5,
     },
     rotation: 0,
+    ignorePolarRotation: false,
     visible: true,
   };
 
@@ -148,6 +149,10 @@ export class TextElementClass extends EmphasizableMarkClass<
       props.alignment.yMargin
     );
     const p = cs.getLocalTransform(attrs.x + offset.x, attrs.y + offset.y);
+    
+    if (this.object.properties.ignorePolarRotation) {
+      p.angle = 0;
+    }
     p.angle += props.rotation;
     let text: Graphics.Element = null;
     const textContent =
@@ -256,6 +261,7 @@ export class TextElementClass extends EmphasizableMarkClass<
         text: attrs.text,
         alignment: props.alignment,
         rotation: props.rotation,
+        ignorePolarRotation: props.ignorePolarRotation
       },
     ];
   }
@@ -421,6 +427,14 @@ export class TextElementClass extends EmphasizableMarkClass<
               searchSection: strings.objects.anchorAndRotation,
             }
           ),
+          manager.inputBoolean(
+            { property: "ignorePolarRotation" },
+            {
+              label: strings.objects.ignorePolarRotation,
+              searchSection: strings.objects.anchorAndRotation,
+              type: "checkbox"
+            }
+          )
         ]
       ),
       manager.verticalGroup(

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -409,6 +409,7 @@ export const strings = {
     logarithmic: "Logarithmic",
   },
   objects: {
+    ignorePolarRotation: "Ignore polar coordinate rotation",
     default: "Default",
     opposite: "Opposite",
     position: "Position",


### PR DESCRIPTION
Property allow to keep text rotation oriented in cartesian coordinates

Property:
![image](https://github.com/user-attachments/assets/d81e2d05-bb29-442e-86a7-0479bfd500d4)

Demo:
![image](https://github.com/user-attachments/assets/ac7cb2e8-53f8-4034-9d13-9b29e995b9bf)
