### PR TITLE
New scale editor with creator

### DIFF
--- a/sass/components/canvas/attribute_editor.scss
+++ b/sass/components/canvas/attribute_editor.scss
@@ -547,7 +547,7 @@
   }
 
   &__object-scales {
-    margin-left: -20px;
+    // margin-left: -20px;
   }
 
   &__widget-container {

--- a/src/app/stores/action_handlers/document.ts
+++ b/src/app/stores/action_handlers/document.ts
@@ -488,9 +488,7 @@ export default function (REG: ActionHandlerRegistry<AppStore, Actions.Action>) {
 
     this.chartManager.chart.constraints = [];
 
-    const glyphs = this.chartManager.chart.glyphs.filter(
-      (glyph) => constraints.find((constraint) => constraint.parentObjectID === glyph._id)
-    );
+    const glyphs = this.chartManager.chart.glyphs;
 
     glyphs.forEach((glyph) => {
       glyph.constraints = [];

--- a/src/app/views/menubar.tsx
+++ b/src/app/views/menubar.tsx
@@ -119,7 +119,7 @@ export class HelpButton extends React.Component<
                       <a
                         target="_blank"
                         href="https://ilfat-galiev.im/pages/about"
-                        onClick={this.props.handlers.onAboutClick}
+                        onClick={this.props.handlers?.onAboutClick}
                       >
                         {strings.help.aboutMeUs}
                       </a>

--- a/src/app/views/panels/adv_scale_editor.tsx
+++ b/src/app/views/panels/adv_scale_editor.tsx
@@ -5,19 +5,19 @@
 import * as React from "react";
 
 import { Prototypes, Specification } from "../../../core";
-import { Actions } from "../../actions";
-import { EditableTextView } from "../../components";
+// import { Actions } from "../../actions";
 
 import { AppStore } from "../../stores";
 import { FluentUIWidgetManager } from "./widgets/fluentui_manager";
 import { strings } from "../../../strings";
 // import { AddRegular, DeleteRegular } from "@fluentui/react-icons";
-import { Dropdown, Label, Option } from "@fluentui/react-components";
+import { Dropdown, Input, Label, Option } from "@fluentui/react-components";
 import { FluentColumnLayout } from "./widgets/controls/fluentui_customized_components";
 import { TableType } from "../../../core/dataset";
 
 export interface ScaleEditorProps {
     store: AppStore;
+    onScaleChange: (scale: Specification.Scale<Specification.ObjectProperties>, scaleClass: Prototypes.Scales.ScaleClass<Specification.AttributeMap, Specification.AttributeMap>) => void;
 }
 
 export const ScaleClassList = [
@@ -33,7 +33,8 @@ export const ScaleClassList = [
 ]
 
 export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
-    store
+    store,
+    onScaleChange
 }) => {
     const chartManager = store.chartManager;
 
@@ -89,6 +90,7 @@ export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
 
         return [newScale, scaleClass];
     }, [scaleClassName, values, chartManager]);
+    onScaleChange(scale, scaleClass);
 
     const manager = React.useMemo(() => {
         if (!scaleClass) {
@@ -148,17 +150,11 @@ export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
                 })}
             </Dropdown>
             <Label>{strings.scaleEditor.name}</Label>
-            <EditableTextView
-                text={scale ? scale.properties.name : "New scale name"}
-                onEdit={(newText) => {
+            <Input
+                value={scale ? scale.properties.name : ""}
+                onChange={(_, { value }) => {
                     if (scale) {
-                        new Actions.SetObjectProperty(
-                            scale,
-                            "name",
-                            null,
-                            newText,
-                            true
-                        ).dispatch(store.dispatcher);
+                        scale.properties.name = value;
                     }
                 }}
             />

--- a/src/app/views/panels/adv_scale_editor.tsx
+++ b/src/app/views/panels/adv_scale_editor.tsx
@@ -82,10 +82,17 @@ export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
         if (!table || !domainSourceColumn) {
             return null;
         }
+        let expression = '';
+        if (domainSourceColumn.split(" ").length > 1) {
+            expression = "`" + domainSourceColumn + "`";
+        } else {
+            expression = `first(${domainSourceColumn})`;
+        }
+        
         const values = chartManager.getGroupedExpressionVector(
             table.name,
             null, // groupBy, no glyph context
-            `first(${domainSourceColumn})`
+            expression
           ) as number[] | string[];
 
           return values;

--- a/src/app/views/panels/adv_scale_editor.tsx
+++ b/src/app/views/panels/adv_scale_editor.tsx
@@ -14,12 +14,18 @@ import { strings } from "../../../strings";
 import { Dropdown, Input, Label, Option } from "@fluentui/react-components";
 import { FluentColumnLayout } from "./widgets/controls/fluentui_customized_components";
 import { TableType } from "../../../core/dataset";
+import { Actions } from "../../actions";
 
 export interface ScaleEditorProps {
     store: AppStore;
     // scale for editing
     scale: Specification.Scale<Specification.ObjectProperties>,
-    onScaleChange: (scale: Specification.Scale<Specification.ObjectProperties>, scaleClass: Prototypes.Scales.ScaleClass<Specification.AttributeMap, Specification.AttributeMap>) => void;
+    onScaleChange: (
+        scale: Specification.Scale<Specification.ObjectProperties>,
+        scaleClass: Prototypes.Scales.ScaleClass<Specification.AttributeMap, Specification.AttributeMap>,
+        domainSourceColumn: string,
+        table: Prototypes.Dataflow.DataflowTable
+    ) => void;
 }
 
 export const ScaleClassList = [
@@ -44,7 +50,6 @@ export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
     const [scaleClassName, setScaleClass] = React.useState<string>(editing?.classID);
 
     // todo load current column from expression
-    debugger;
     const [domainSourceColumn, setDomainSourceColumn] = React.useState<string>(null);
 
     const table = React.useMemo(() => {
@@ -99,7 +104,7 @@ export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
 
         return [newScale, scaleClass];
     }, [scaleClassName, values, chartManager, editing]);
-    onScaleChange(scale, scaleClass);
+    onScaleChange(scale, scaleClass, domainSourceColumn, table);
 
     const manager = React.useMemo(() => {
         if (!scaleClass) {
@@ -110,9 +115,17 @@ export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
             scaleClass,
             true
         );
+        manager.onEditMappingHandler = (
+            attribute: string,
+            mapping: Specification.Mapping
+          ) => {
+            new Actions.SetScaleAttribute(scale, attribute, mapping).dispatch(
+              store.dispatcher
+            );
+          };
 
         return manager;
-    }, [scaleClass, store]);
+    }, [scaleClass, store, scale]);
 
     // todo: create react hook
     // eslint-disable-next-line powerbi-visuals/insecure-random, @typescript-eslint/no-unused-vars

--- a/src/app/views/panels/adv_scale_editor.tsx
+++ b/src/app/views/panels/adv_scale_editor.tsx
@@ -167,6 +167,7 @@ export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
         <FluentColumnLayout>
             <Label>{strings.scaleEditor.type}</Label>
             <Dropdown
+                disabled={!!editing}
                 title={strings.scaleEditor.type}
                 value={scale?.classID}
                 onOptionSelect={(_, { optionValue: scaleClassName }) => {

--- a/src/app/views/panels/adv_scale_editor.tsx
+++ b/src/app/views/panels/adv_scale_editor.tsx
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as React from "react";
+
+import { EventSubscription, Prototypes, Specification, uniqueID } from "../../../core";
+import { Actions } from "../../actions";
+import { EditableTextView, SVGImageIcon } from "../../components";
+
+import { AppStore } from "../../stores";
+import { FluentUIWidgetManager } from "./widgets/fluentui_manager";
+import { ReservedMappingKeyNamePrefix } from "../../../core/prototypes/legends/categorical_legend";
+import { strings } from "../../../strings";
+import { AttributeMap } from "../../../core/specification";
+import { ObjectClass } from "../../../core/prototypes";
+import { EventType } from "./widgets/observer";
+import { ScaleEditorWrapper } from "./panel_styles";
+import { Button } from "@fluentui/react-button";
+import * as R from "../../resources";
+import { AddRegular, DeleteRegular } from "@fluentui/react-icons";
+import { Dropdown, Option } from "@fluentui/react-components";
+
+export interface ScaleEditorProps {
+    scale: Specification.Scale;
+    scaleMapping: Specification.ScaleMapping;
+    store: AppStore;
+    plotSegment: ObjectClass;
+}
+
+export const ScaleClassList = [
+    "scale.categorical<string,image>",
+    "scale.categorical<string,boolean>",
+    "scale.linear<number,boolean>",
+    "scale.categorical<string,color>",
+    "scale.categorical<date,color>"
+]
+
+export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
+    store
+}) => {
+    const chartManager = store.chartManager;
+
+    const [scaleClass, setScaleClass] = React.useState<ObjectClass<Specification.AttributeMap, Specification.AttributeMap>>(null);
+
+    const [scale, setScale] = React.useState<Specification.Scale>(null);
+
+    var manager = React.useMemo(() => {
+        const manager = new FluentUIWidgetManager(
+            store,
+            scaleClass,
+            true
+        );
+
+        return manager;
+    }, [scaleClass]);
+
+    // todo: create react hook
+    const [_, setUpdate] = React.useState(Math.random());
+    React.useEffect(() => {
+        var token = store.addListener(AppStore.EVENT_GRAPHICS, () => {
+            setUpdate(Math.random());
+        });
+
+        return () => {
+            token.remove();
+        }
+    }, []);
+
+    return (
+        <ScaleEditorWrapper className="scale-editor-view">
+            <div className="attribute-editor">
+                <section className="attribute-editor-element">
+                    <div className="header">
+                        <Dropdown
+                            title="scale type"
+                            value={scale.classID}
+                            onOptionSelect={(_, { optionValue: classID }) => {
+                                debugger;
+                                const newScale = chartManager.createObject(
+                                    classID
+                                ) as Specification.Scale;
+
+                                newScale.properties.name = chartManager.findUnusedName("Scale");
+
+                                const scaleClass = chartManager.getClassById(
+                                    newScale._id
+                                ) as Prototypes.Scales.ScaleClass;
+
+                                setScaleClass(scaleClass);
+                                setScale(newScale);
+                            }}
+                        >
+                            {
+                                ScaleClassList.map(className => {
+                                    return (
+                                        <Option text={className} value={className} key={className}>
+                                            {className}
+                                        </Option>);
+                                })
+                            }
+                        </Dropdown>
+                        <EditableTextView
+                            text={scale ? scale.properties.name : "New scale name"}
+                            onEdit={(newText) => {
+                                if (scale) {
+                                    new Actions.SetObjectProperty(
+                                        scale,
+                                        "name",
+                                        null,
+                                        newText,
+                                        true
+                                    ).dispatch(store.dispatcher);
+                                }
+                            }}
+                        />
+                    </div>
+                    {manager.vertical(...scaleClass.getAttributePanelWidgets(manager))}
+                    <div className="action-buttons">
+                    </div>
+                </section>
+            </div>
+        </ScaleEditorWrapper>
+    );
+} 

--- a/src/app/views/panels/adv_scale_editor.tsx
+++ b/src/app/views/panels/adv_scale_editor.tsx
@@ -17,6 +17,8 @@ import { TableType } from "../../../core/dataset";
 
 export interface ScaleEditorProps {
     store: AppStore;
+    // scale for editing
+    scale: Specification.Scale<Specification.ObjectProperties>,
     onScaleChange: (scale: Specification.Scale<Specification.ObjectProperties>, scaleClass: Prototypes.Scales.ScaleClass<Specification.AttributeMap, Specification.AttributeMap>) => void;
 }
 
@@ -34,12 +36,15 @@ export const ScaleClassList = [
 
 export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
     store,
+    scale: editing,
     onScaleChange
 }) => {
     const chartManager = store.chartManager;
 
-    const [scaleClassName, setScaleClass] = React.useState<string>(null);
+    const [scaleClassName, setScaleClass] = React.useState<string>(editing?.classID);
 
+    // todo load current column from expression
+    debugger;
     const [domainSourceColumn, setDomainSourceColumn] = React.useState<string>(null);
 
     const table = React.useMemo(() => {
@@ -70,12 +75,14 @@ export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
         if (!scaleClassName) {
             return [null, null];
         }
-        const newScale = chartManager.createObject(
+        const newScale = editing ? editing : chartManager.createObject(
             scaleClassName
         ) as Specification.Scale;
 
-        newScale.properties.name = chartManager.findUnusedName("Scale");
-        chartManager.addScale(newScale);
+        if (!editing) {
+            newScale.properties.name = chartManager.findUnusedName("Scale");
+            chartManager.addScale(newScale);
+        }
         const scaleClass = chartManager.getClassById(
             newScale._id
         ) as Prototypes.Scales.ScaleClass;
@@ -86,10 +93,12 @@ export const AdvancedScaleEditor: React.FC<ScaleEditorProps> = ({
                 reuseRange: false
             })
         }
-        chartManager.removeScale(newScale);
+        if (!editing) {
+            chartManager.removeScale(newScale);
+        }
 
         return [newScale, scaleClass];
-    }, [scaleClassName, values, chartManager]);
+    }, [scaleClassName, values, chartManager, editing]);
     onScaleChange(scale, scaleClass);
 
     const manager = React.useMemo(() => {

--- a/src/app/views/panels/constraints_panel.tsx
+++ b/src/app/views/panels/constraints_panel.tsx
@@ -252,6 +252,7 @@ const ConstraintView: React.FC<{
                 onOptionSelect={(_, { optionValue: value }) => {
                     const newConstraint = { ...constraint };
                     newConstraint.parentObjectID = value;
+                    newConstraint.parentObjectType = parents.find(p => p._id == value).classID === 'chart.rectangle' ? 'chart' : 'glyph';
                     onConstraintChange(newConstraint);
                 }}
             >

--- a/src/app/views/panels/constraints_panel.tsx
+++ b/src/app/views/panels/constraints_panel.tsx
@@ -32,20 +32,23 @@ export const ConstraintsPanel: React.FC<{
     // eslint-disable-next-line powerbi-visuals/insecure-random
     const [_, forceUpdate] = React.useState(Math.random());
 
+    const chart = store.chartManager.chart;
+    const glyphs = store.chartManager.chart.glyphs;
+
     const updateConstraintsList = React.useCallback(() => {
         // eslint-disable-next-line powerbi-visuals/insecure-random
-        const glyphConstraints: Specification.ObjectConstraint[] = store.chartManager.chart.glyphs.flatMap((glyph) => glyph.constraints.map((constraint) => ({
+        const glyphConstraints: Specification.ObjectConstraint[] = glyphs.flatMap((glyph) => glyph.constraints.map((constraint) => ({
             ...constraint,
             parentObjectID: glyph._id,
             parentObjectType: "glyph"
         })));
-        const generalConstraints: Specification.ObjectConstraint[] = store.chartManager.chart.constraints.map((constraint) => ({
+        const generalConstraints: Specification.ObjectConstraint[] = chart.constraints.map((constraint) => ({
             ...constraint,
-            parentObjectID: store.chartManager.chart._id,
+            parentObjectID: chart._id,
             parentObjectType: "chart"
         }));
         setConstraints([].concat(glyphConstraints, generalConstraints));
-    }, [setConstraints]);
+    }, [setConstraints, chart, glyphs]);
 
     React.useEffect(() => {
         updateConstraintsList();
@@ -64,7 +67,7 @@ export const ConstraintsPanel: React.FC<{
         return () => {
             tokens.current.forEach((token) => token.remove());
         };
-    }, [store, setConstraints]);
+    }, [store, setConstraints, updateConstraintsList]);
 
     const getGlyphState = React.useCallback((glyph: Specification.Glyph) => {
         const chartStore = store;
@@ -206,6 +209,7 @@ export const ConstraintsPanel: React.FC<{
                             setConstraints(newConstraints);
                         }}
                         onRemove={() => {
+                            debugger;
                             const newConstraints = [...constraints];
                             const index = newConstraints.findIndex(c => c._id === constraint._id);
                             newConstraints.splice(index, 1);

--- a/src/app/views/panels/scales_panel.tsx
+++ b/src/app/views/panels/scales_panel.tsx
@@ -428,10 +428,18 @@ export class ScalesPanel extends ContextedComponent<
                           return;
                         }
                         const valueType = column.type;
+
+                        let expression = '';
+                        if (this.state.domainSourceColumn.split(" ").length > 1) {
+                            expression = "`" + this.state.domainSourceColumn + "`";
+                        } else {
+                            expression = `first(${this.state.domainSourceColumn})`;
+                        }
+
                         property.mark.mappings[property.property] = {
                           type: MappingType.scale,
                           table: this.state.domainSourceTable,
-                          expression: `first(${this.state.domainSourceColumn})`,
+                          expression: expression,
                           valueType: valueType,
                           scale: this.state.scale._id,
                           attribute: property.property,

--- a/src/app/views/panels/scales_panel.tsx
+++ b/src/app/views/panels/scales_panel.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as R from "../../resources";
 
-import { EventSubscription, Prototypes, Expression } from "../../../core";
+import { EventSubscription, Prototypes, Expression, Specification } from "../../../core";
 import { SVGImageIcon, DraggableElement } from "../../components";
 
 import { AppStore } from "../../stores";
@@ -24,7 +24,7 @@ import { FunctionCall, Variable } from "../../../core/expression";
 import { ColumnMetadata } from "../../../core/dataset";
 import { Button, Dialog, DialogActions, DialogBody, DialogSurface, DialogTitle } from "@fluentui/react-components";
 import { strings } from "../../../strings";
-import { AdvancedScaleEditor } from "./adv_scale_editor";
+import { AdvancedScaleEditor, ScaleEditorProps } from "./adv_scale_editor";
 
 export class ScalesPanel extends ContextedComponent<
   {
@@ -33,6 +33,8 @@ export class ScalesPanel extends ContextedComponent<
   {
     isSelected: string;
     createDialog: boolean;
+    scale: Specification.Scale<Specification.ObjectProperties>,
+    scaleClass: Prototypes.Scales.ScaleClass<Specification.AttributeMap, Specification.AttributeMap>
   }
 > {
   public mappingButton: Element;
@@ -42,7 +44,9 @@ export class ScalesPanel extends ContextedComponent<
     super(props, null);
     this.state = {
       isSelected: "",
-      createDialog: false
+      createDialog: false,
+      scale: null,
+      scaleClass: null
     };
   }
 
@@ -340,6 +344,16 @@ export class ScalesPanel extends ContextedComponent<
             <DialogBody>
               <AdvancedScaleEditor
                 store={this.context.store}
+                onScaleChange={(scale, scaleClass) => {
+                  if (scale != this.state.scale) {
+                    debugger;
+                    // TODO move dialog into AdvancedScaleEditor
+                    this.setState({
+                      scale,
+                      scaleClass
+                    });
+                  }
+                }}
               />
               <DialogActions>
                 <Button onClick={() => {
@@ -354,8 +368,12 @@ export class ScalesPanel extends ContextedComponent<
                     width: 100
                   }}
                   onClick={() => {
-
-                }}>
+                    store.chartManager.addScale(this.state.scale);
+                    store.emit(AppStore.EVENT_GRAPHICS);
+                    this.setState({
+                      createDialog: false
+                    });
+                  }}>
                   {strings.scaleEditor.createScale}
                 </Button>
               </DialogActions>

--- a/src/app/views/panels/scales_panel.tsx
+++ b/src/app/views/panels/scales_panel.tsx
@@ -366,6 +366,7 @@ export class ScalesPanel extends ContextedComponent<
           })}
         </ReorderListView>
         <Dialog
+          onOpenChange={(e, { open }) => this.setState({createDialog: open})}
           modalType={"non-modal"}
           open={this.state.createDialog}>
           <DialogSurface>

--- a/src/app/views/panels/scales_panel.tsx
+++ b/src/app/views/panels/scales_panel.tsx
@@ -35,6 +35,7 @@ export class ScalesPanel extends ContextedComponent<
     createDialog: boolean;
     scale: Specification.Scale<Specification.ObjectProperties>,
     scaleClass: Prototypes.Scales.ScaleClass<Specification.AttributeMap, Specification.AttributeMap>
+    domainSourceTable: string;
     domainSourceColumn: string;
     currentScale: Specification.Scale<Specification.ObjectProperties>
     table: Prototypes.Dataflow.DataflowTable
@@ -52,6 +53,7 @@ export class ScalesPanel extends ContextedComponent<
       scaleClass: null,
       currentScale: null,
       domainSourceColumn: null,
+      domainSourceTable: null,
       table: null
     };
   }
@@ -372,7 +374,7 @@ export class ScalesPanel extends ContextedComponent<
               <AdvancedScaleEditor
                 store={this.context.store}
                 scale={this.state.currentScale}
-                onScaleChange={(scale, scaleClass, domainSourceColumn, table) => {
+                onScaleChange={(scale, scaleClass, domainSourceTable, domainSourceColumn, table) => {
                   const newState: any = {};
                   if (scale != this.state.scale) {
                     // TODO move dialog into AdvancedScaleEditor
@@ -380,6 +382,9 @@ export class ScalesPanel extends ContextedComponent<
                   }
                   if (scaleClass != this.state.scaleClass) {
                     newState.scaleClass = scaleClass;
+                  }
+                  if (domainSourceTable != this.state.domainSourceTable) {
+                    newState.domainSourceTable = domainSourceTable;
                   }
                   if (domainSourceColumn != this.state.domainSourceColumn) {
                     newState.domainSourceColumn = domainSourceColumn;
@@ -416,11 +421,8 @@ export class ScalesPanel extends ContextedComponent<
                     if (!this.state.currentScale) {
                       store.chartManager.addScale(this.state.scale);
                     } else {
-                      // TODO revisit marks to update expression
-                      console.log('propertyList', propertyList);
                       const property = propertyList.find(p => p.scale._id == this.state.currentScale._id && !!p.property && !!p.mark);
                       if (property) {
-                        debugger;
                         const column = this.state.table.columns.find(col => col.displayName == this.state.domainSourceColumn);
                         if (!column) {
                           return;
@@ -428,7 +430,7 @@ export class ScalesPanel extends ContextedComponent<
                         const valueType = column.type;
                         property.mark.mappings[property.property] = {
                           type: MappingType.scale,
-                          table: this.state.table.name,
+                          table: this.state.domainSourceTable,
                           expression: `first(${this.state.domainSourceColumn})`,
                           valueType: valueType,
                           scale: this.state.scale._id,

--- a/src/app/views/panels/scales_panel.tsx
+++ b/src/app/views/panels/scales_panel.tsx
@@ -22,6 +22,9 @@ import { Actions, DragData } from "../..";
 import { classNames } from "../../utils";
 import { FunctionCall, Variable } from "../../../core/expression";
 import { ColumnMetadata } from "../../../core/dataset";
+import { Button, Dialog, DialogActions, DialogBody, DialogSurface, DialogTitle } from "@fluentui/react-components";
+import { strings } from "../../../strings";
+import { AdvancedScaleEditor } from "./adv_scale_editor";
 
 export class ScalesPanel extends ContextedComponent<
   {
@@ -29,6 +32,7 @@ export class ScalesPanel extends ContextedComponent<
   },
   {
     isSelected: string;
+    createDialog: boolean;
   }
 > {
   public mappingButton: Element;
@@ -38,6 +42,7 @@ export class ScalesPanel extends ContextedComponent<
     super(props, null);
     this.state = {
       isSelected: "",
+      createDialog: false
     };
   }
 
@@ -199,9 +204,8 @@ export class ScalesPanel extends ContextedComponent<
                   Prototypes.ObjectClasses.GetMetadata(element.classID).iconPath
                 )}
               />
-              <span className="el-text">{`${
-                element.properties.name
-              }.${this.getPropertyDisplayName(key)}`}</span>
+              <span className="el-text">{`${element.properties.name
+                }.${this.getPropertyDisplayName(key)}`}</span>
             </DraggableElement>
           </div>
         );
@@ -327,6 +331,37 @@ export class ScalesPanel extends ContextedComponent<
             return mapToUI(el.scale)(el.glyph, el.mark)(el.property);
           })}
         </ReorderListView>
+        <Button onClick={() => this.setState({ createDialog: true })}>{strings.scaleEditor.createScale}</Button>
+        <Dialog
+          modalType={"non-modal"}
+          open={this.state.createDialog}>
+          <DialogSurface>
+            <DialogTitle>{strings.scaleEditor.createScale}</DialogTitle>
+            <DialogBody>
+              <AdvancedScaleEditor
+                store={this.context.store}
+              />
+              <DialogActions>
+                <Button onClick={() => {
+                  this.setState({
+                    createDialog: false
+                  });
+                }}>
+                  {strings.scaleEditor.close}
+                </Button>
+                <Button
+                  style={{
+                    width: 100
+                  }}
+                  onClick={() => {
+
+                }}>
+                  {strings.scaleEditor.createScale}
+                </Button>
+              </DialogActions>
+            </DialogBody>
+          </DialogSurface>
+        </Dialog>
       </div>
     );
   }

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -149,7 +149,8 @@ export const strings = {
   scaleEditor: {
     name: "Scale name",
     save: "Save scale",
-    domainSourceColumn: "Domain source",
+    domainSourceTable: "Domain source table",
+    domainSourceColumn: "Domain source column",
     type: "Scale type",
     createScale: "Create scale",
     close: "Close",

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -94,8 +94,8 @@ export const strings = {
     gap: "Gap",
     element: "Element",
     elementAttribute: "Element attribute",
-    target: "Element",
-    targetAttribute: "Element attribute",
+    target: "Target",
+    targetAttribute: "Target attribute",
     remove: "Remove",
     save: "Save"
   },

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -148,6 +148,7 @@ export const strings = {
   },
   scaleEditor: {
     name: "Scale name",
+    save: "Save scale",
     domainSourceColumn: "Domain source",
     type: "Scale type",
     createScale: "Create scale",

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -147,6 +147,11 @@ export const strings = {
     deleteChart: "Delete chart",
   },
   scaleEditor: {
+    name: "Scale name",
+    domainSourceColumn: "Domain source",
+    type: "Scale type",
+    createScale: "Create scale",
+    close: "Close",
     add: "Add",
     removeLast: "Remove the last",
     addLegend: "Add Legend",


### PR DESCRIPTION
The new scale ediotor will allow precreate scale, before apply to mark attributes.
It's the first feature for shared scales for nested charts

![scale-editor](https://github.com/user-attachments/assets/9d1e3b02-7c08-4c84-b804-9116f54c937e)

Pr unlocks implementation of https://github.com/microsoft/charticulator/pull/965
